### PR TITLE
fix GPU & non-openfast builds

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -459,8 +459,8 @@ class Realm {
   TurbulenceAveragingPostProcessing *turbulenceAveragingPostProcessing_;
   DataProbePostProcessing *dataProbePostProcessing_;
   Actuator *actuator_;
-  std::unique_ptr<ActuatorMetaFAST> actuatorMeta_;
-  std::unique_ptr<ActuatorBulkFAST> actuatorBulk_;
+  std::shared_ptr<ActuatorMetaFAST> actuatorMeta_;
+  std::shared_ptr<ActuatorBulkFAST> actuatorBulk_;
   ABLForcingAlgorithm *ablForcingAlg_;
   BdyLayerStatistics* bdyLayerStats_{nullptr};
   std::unique_ptr<MeshMotionAlg> meshMotionAlg_;

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -631,7 +631,7 @@ Realm::look_ahead_and_creation(const YAML::Node & node)
     switch ( ActuatorTypeMap[ActuatorTypeName] ) {
         case ActuatorType::ActLineFASTNGP : {
 #ifdef NALU_USES_OPENFAST
-          actuatorMeta_ = make_unique<ActuatorMetaFAST>(actuator_FAST_parse(node, actMeta));
+          actuatorMeta_ = std::make_shared<ActuatorMetaFAST>(actuator_FAST_parse(node, actMeta));
           break;
 #else
 	throw std::runtime_error("look_ahead_and_create::error: Requested actuator type: " + ActuatorTypeName + ", but was not enabled at compile time");
@@ -1041,7 +1041,7 @@ Realm::setup_post_processing_algorithms()
 
   if (NULL != actuatorMeta_)
   {
-    actuatorBulk_ = make_unique<ActuatorBulkFAST>(*actuatorMeta_.get(),
+    actuatorBulk_ = std::make_shared<ActuatorBulkFAST>(*actuatorMeta_.get(),
        get_time_step_from_file());
   }
 
@@ -2028,12 +2028,13 @@ Realm::advance_time_step()
   }
 
   // check for actuator line; assemble the source terms for this time step
+#ifdef NALU_USES_OPENFAST
   if ( NULL != actuatorBulk_ ) {
     ActuatorLineFastNGP(*actuatorMeta_.get(),
       *actuatorBulk_.get(),
       bulk_data())();
   }
-
+#endif
   // Check for ABL forcing; estimate source terms for this time step
   if ( NULL != ablForcingAlg_) {
     ablForcingAlg_->execute();

--- a/src/actuator/ActuatorBulkDiskFAST.C
+++ b/src/actuator/ActuatorBulkDiskFAST.C
@@ -26,7 +26,7 @@ ActuatorBulkDiskFAST::ActuatorBulkDiskFAST(ActuatorMetaFAST& actMeta, double nal
   resize_arrays(actMeta);
   Kokkos::parallel_for("ZeroArrays",
     Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,actMeta.numPointsTotal_),
-    KOKKOS_LAMBDA(int index)
+    [&](int index)
     {
     for(int j=0; j<3; j++){
       pointCentroid_.h_view(index, j)=0;

--- a/unit_tests/actuator/UnitTestActuatorFunctorsFAST.C
+++ b/unit_tests/actuator/UnitTestActuatorFunctorsFAST.C
@@ -210,7 +210,7 @@ TEST_F(ActuatorFunctorFASTTests, runAssignVelAndComputeForces){
 
   Kokkos::parallel_for("checkAnswers",
     Kokkos::RangePolicy<ActuatorFixedExecutionSpace>(0,actMetaFast.numPointsTotal_),
-    KOKKOS_LAMBDA(int i){
+    [&](int i){
     for(int j=0; j<3; ++j){
       EXPECT_DOUBLE_EQ(fastForces(i,j), force(i,j));
     }

--- a/unit_tests/actuator/UnitTestActuatorSearch.C
+++ b/unit_tests/actuator/UnitTestActuatorSearch.C
@@ -22,7 +22,7 @@ namespace {
 
 class ActuatorSearchTest : public ::testing::Test
 {
-protected:
+public:
   ActuatorSearchTest()
     : nProcs(NaluEnv::self().parallel_size()),
       myRank(NaluEnv::self().parallel_rank()),


### PR DESCRIPTION
* Fix GPU build, mainly by not marking some lambda's as `__device__` lambdas.
* Fix non-openfast build.  Just changed over the actuator pointers to shared pointers to avoid complaints about the destructor not being available when openfast isn't enabled